### PR TITLE
Increase block size to match receive buffer size of 512 bytes 

### DIFF
--- a/isotp_config.h
+++ b/isotp_config.h
@@ -4,7 +4,7 @@
 /* Max number of messages the receiver can receive at one time, this value 
  * is affectied by can driver queue length
  */
-#define ISO_TP_DEFAULT_BLOCK_SIZE   8
+#define ISO_TP_DEFAULT_BLOCK_SIZE   64
 
 /* The STmin parameter value specifies the minimum time gap allowed between 
  * the transmission of consecutive frame network protocol data units


### PR DESCRIPTION
Increasing the block size of the receiver to match the size of the receive buffer of 512 bytes. This allows us to send data to a receiver without the need for flow control at the iso-tp level for messages less than 512 bytes. This change is necessary for sending pattern data notifications over CAN, which are 202 bytes, as fast as possible using iso-tp. 

I found that this change was needed once I integrating pattern streaming into vega2_api in this PR: https://github.com/unspun/vega2-firmware/pull/779/files