### PR TITLE
adjust block size to match CAN FIFO depth

### DIFF
--- a/isotp_config.h
+++ b/isotp_config.h
@@ -4,7 +4,7 @@
 /* Max number of messages the receiver can receive at one time, this value 
  * is affectied by can driver queue length
  */
-#define ISO_TP_DEFAULT_BLOCK_SIZE   64
+#define ISO_TP_DEFAULT_BLOCK_SIZE   3
 
 /* The STmin parameter value specifies the minimum time gap allowed between 
  * the transmission of consecutive frame network protocol data units


### PR DESCRIPTION
The block size in ISO-TP dictates how many CAN frames the receiver can receive before requiring another flow control hand shake between sender and receiver. Adjusting this block size to align with the CAN transceivers FIFO depth to avoid overrunning the FIFO on the receiver. Found during pattern streaming testing, where a pattern data message gets split into 26 frames and are sent back to back without delay. The processing of the CAN interrupt on the receive side is too slow and we hit the CAN overrun quickly